### PR TITLE
Tune Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,4 @@
-a1: alertmanager --storage.path=a1 --web.listen-address=:9093 --cluster.listen-address=:8001 --config.file=alertmanager.yaml
-a2: alertmanager --storage.path=a2 --web.listen-address=:9094 --cluster.listen-address=:8002 --cluster.peer=127.0.0.1:8001 --config.file=alertmanager.yaml
-a3: alertmanager --storage.path=a3 --web.listen-address=:9095 --cluster.listen-address=:8003 --cluster.peer=127.0.0.1:8001 --config.file=alertmanager.yaml
+a1: alertmanager --storage.path=a1 --web.listen-address=:9093 --cluster.listen-address=:8001 --cluster.peer=127.0.0.1:8002 --cluster.peer=127.0.0.1:8003 --config.file=alertmanager.yaml --cluster.peer-timeout=2s
+a2: alertmanager --storage.path=a2 --web.listen-address=:9094 --cluster.listen-address=:8002 --cluster.peer=127.0.0.1:8001 --cluster.peer=127.0.0.1:8003 --config.file=alertmanager.yaml --cluster.peer-timeout=2s
+a3: alertmanager --storage.path=a3 --web.listen-address=:9095 --cluster.listen-address=:8003 --cluster.peer=127.0.0.1:8001 --cluster.peer=127.0.0.1:8002 --config.file=alertmanager.yaml --cluster.peer-timeout=2s
 p: prometheus --config.file=prometheus.yml
-


### PR DESCRIPTION
Since goreman starts all AlertManager instances simultaneously, it is
safer to provide all peer addresses to AlertManager. Otherwise the
cluster may be incomplete.

This change also lowers the peer.timeout parameter from 15s (default) to
2s. It means that the peers at position 1 and 2 will wait respectively
2s and 4s (instead of 15s and 30s) before effectively starting the
notification stage.